### PR TITLE
Variable parsing

### DIFF
--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -52,7 +52,7 @@ $wpdb->pmpro_discount_codes_uses = PMPRO_NETWORK_MAIN_DB_PREFIX . '_pmpro_discou
 //get levels again
 function pmpron_init_get_levels() {
 	global $wpdb, $membership_levels;
-	$membership_levels = $wpdb->get_results( 'SELECT * FROM {$wpdb->pmpro_membership_levels}', OBJECT );
+	$membership_levels = $wpdb->get_results( "SELECT * FROM {$wpdb->pmpro_membership_levels}", OBJECT );
 }
 add_action( 'init', 'pmpron_init_get_levels', 1 );
 


### PR DESCRIPTION
https://github.com/strangerstudios/pmpro-network-subsite/commit/b50c9efe3ac849bb094e5a641ddc4f56bb854834 introduced an issue, There is a variable used in a string on line 55, the change to single quotes means you're passing `{$wpdb->pmpro_membership_levels` directly to the database, which I don't think is going to work.