### PR TITLE
Localization and Escaping

### DIFF
--- a/inc/class-pmpro-manage-multisite.php
+++ b/inc/class-pmpro-manage-multisite.php
@@ -19,7 +19,7 @@ class PMPro_Manage_Multisite {
 	 *
 	 */
 	public static function add_admin_menu() {
-		add_menu_page( esc_html__( 'Memberships', 'pmpro-multisite-membership' ), esc_html__( 'Memberships', 'pmpro-multisite-membership' ), 'manage_options', 'pmpro-multisite-membership', array( __CLASS__, 'settings_page' ), 'dashicons-groups' );
+		add_menu_page( esc_html__( 'Memberships', 'pmpro-network-subsite' ), esc_html__( 'Memberships', 'pmpro-network-subsite' ), 'manage_options', 'pmpro-network-subsite', array( __CLASS__, 'settings_page' ), 'dashicons-groups' );
 	}
 
 	/**
@@ -46,7 +46,7 @@ class PMPro_Manage_Multisite {
 
 			?>
 			<div class="notice notice-success is-dismissible">
-		        <p><?php esc_html_e( 'The source site has been updated. Make sure that PMPro IS active on that site and the Multisite Membership Add On IS NOT active there.', 'pmpro-multisite-membership' ); ?></p>
+		        <p><?php esc_html_e( 'The source site has been updated. Make sure that PMPro IS active on that site and the Multisite Membership Add On IS NOT active there.', 'pmpro-network-subsite' ); ?></p>
 		    </div>
 			<?php
 		}
@@ -56,10 +56,10 @@ class PMPro_Manage_Multisite {
 		// Show the form.
 		?>
 		<div class="wrap">
-		<h2><?php esc_html_e( 'PMPro Multisite Membership Settings', 'pmpro-multisite-membership' ); ?></h2>
-		<p><?php printf( esc_html__( 'You have activated the %s on this site, which means that you will be using PMPro settings from another site in your Network to control site access.', 'pmpro-multisite-membership' ), '<strong>' . __( 'Multisite Membership Add On', 'pmpro-multisite-membership' ) . '</strong>' );?></p>
+		<h2><?php esc_html_e( 'PMPro Multisite Membership Settings', 'pmpro-network-subsite' ); ?></h2>
+		<p><?php printf( esc_html__( 'You have activated the %s on this site, which means that you will be using PMPro settings from another site in your Network to control site access.', 'pmpro-network-subsite' ), '<strong>' . __( 'Multisite Membership Add On', 'pmpro-network-subsite' ) . '</strong>' );?></p>
 
-		<p><?php esc_html_e( 'Select the site you would like to get PMPro level data from and click Update.', 'pmpro-multisite-membership' );?></p>
+		<p><?php esc_html_e( 'Select the site you would like to get PMPro level data from and click Update.', 'pmpro-network-subsite' );?></p>
 
 		<form id="select-site-form" action="" method="POST">
 			<div>
@@ -79,7 +79,7 @@ class PMPro_Manage_Multisite {
 					}
 				?>	
 				</select>
-				<input type="submit" name="select-site-submit" id="select_site_submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'pmpro-multisite-membership' ); ?>"/>
+				<input type="submit" name="select-site-submit" id="select_site_submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'pmpro-network-subsite' ); ?>"/>
 			</div>
 		</form>
 		</div>

--- a/inc/class-pmpro-manage-multisite.php
+++ b/inc/class-pmpro-manage-multisite.php
@@ -19,7 +19,7 @@ class PMPro_Manage_Multisite {
 	 *
 	 */
 	public static function add_admin_menu() {
-		add_menu_page( __( 'Memberships', 'pmpro-multisite-membership' ), __( 'Memberships', 'pmpro-multisite-membership' ), 'manage_options', 'pmpro-multisite-membership', array( __CLASS__, 'settings_page' ), 'dashicons-groups' );
+		add_menu_page( esc_html__( 'Memberships', 'pmpro-multisite-membership' ), esc_html__( 'Memberships', 'pmpro-multisite-membership' ), 'manage_options', 'pmpro-multisite-membership', array( __CLASS__, 'settings_page' ), 'dashicons-groups' );
 	}
 
 	/**
@@ -46,7 +46,7 @@ class PMPro_Manage_Multisite {
 
 			?>
 			<div class="notice notice-success is-dismissible">
-		        <p><?php _e( 'The source site has been updated. Make sure that PMPro IS active on that site and the Multisite Membership Add On IS NOT active there.', 'pmpro-multisite-membership' ); ?></p>
+		        <p><?php esc_html_e( 'The source site has been updated. Make sure that PMPro IS active on that site and the Multisite Membership Add On IS NOT active there.', 'pmpro-multisite-membership' ); ?></p>
 		    </div>
 			<?php
 		}
@@ -56,10 +56,10 @@ class PMPro_Manage_Multisite {
 		// Show the form.
 		?>
 		<div class="wrap">
-		<h2><?php _e( 'PMPro Multisite Membership Settings', 'pmpro-multisite-membership' ); ?></h2>
-		<p><?php _e( 'You have activated the <strong>Multisite Membership Add On</strong> on this site, which means that you will be using PMPro settings from another site in your Network to control site access.', 'pmpro-multisite-membership' );?></p>
+		<h2><?php esc_html_e( 'PMPro Multisite Membership Settings', 'pmpro-multisite-membership' ); ?></h2>
+		<p><?php printf( esc_html__( 'You have activated the %s on this site, which means that you will be using PMPro settings from another site in your Network to control site access.', 'pmpro-multisite-membership' ), '<strong>' . __( 'Multisite Membership Add On', 'pmpro-multisite-membership' ) . '</strong>' );?></p>
 
-		<p><?php _e( 'Select the site you would like to get PMPro level data from and click Update.', 'pmpro-multisite-membership' );?></p>
+		<p><?php esc_html_e( 'Select the site you would like to get PMPro level data from and click Update.', 'pmpro-multisite-membership' );?></p>
 
 		<form id="select-site-form" action="" method="POST">
 			<div>
@@ -79,7 +79,7 @@ class PMPro_Manage_Multisite {
 					}
 				?>	
 				</select>
-				<input type="submit" name="select-site-submit" id="select_site_submit" class="button-primary" value="<?php _e( 'Update', 'pmpro-multisite-membership' ); ?>"/>
+				<input type="submit" name="select-site-submit" id="select_site_submit" class="button-primary" value="<?php esc_attr_e( 'Update', 'pmpro-multisite-membership' ); ?>"/>
 			</div>
 		</form>
 		</div>

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -6,7 +6,8 @@
  * Version: 0.4.5
  * Author: Paid Memberships Pro
  * Author URI: https://www.paidmembershipspro.com
- * Text-domain: pmpro-multisite-membership
+ * Text-domain: pmpro-network-subsite
+ * Domain Path: /languages
  */
 
 /** 
@@ -112,8 +113,8 @@ add_action( 'init', 'pmpro_multisite_membership_init', 15 );
 function pmpro_multisite_membership_plugin_row_meta( $links, $file ) {
 	if ( strpos( $file, 'pmpro-network-subsite.php' ) !== false ) {
 		$new_links = array(
-			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-network-membership/' ) . '" title="' . esc_attr__( 'View Documentation', 'pmpro-multisite-membership' ) . '">' . esc_html__( 'Docs', 'pmpro-multisite-membership' ) . '</a>',
-			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr__( 'Visit Customer Support Forum', 'pmpro-multisite-membership' ) . '">' . esc_html__( 'Support', 'pmpro-multisite-membership' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-network-membership/' ) . '" title="' . esc_attr__( 'View Documentation', 'pmpro-network-subsite' ) . '">' . esc_html__( 'Docs', 'pmpro-network-subsite' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr__( 'Visit Customer Support Forum', 'pmpro-network-subsite' ) . '">' . esc_html__( 'Support', 'pmpro-network-subsite' ) . '</a>',
 		);
 		$links = array_merge( $links, $new_links );
 	}

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -36,6 +36,12 @@ function pmpro_multisite_membership_get_main_db_prefix() {
 include( 'inc/class-pmpro-manage-multisite.php' );
 PMPro_Manage_Multisite::init();
 
+// Load text domain
+function pmpro_multisite_membership_load_textdomain() {
+	load_plugin_textdomain( 'pmpro-network-subsite', false, basename( dirname( __FILE__ ) ) . '/languages' ); 
+}
+add_action( 'init', 'pmpro_multisite_membership_load_textdomain' );
+
 /*
 	Make sure this plugin loads after Paid Memberships Pro
 */

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -112,8 +112,8 @@ add_action( 'init', 'pmpro_multisite_membership_init', 15 );
 function pmpro_multisite_membership_plugin_row_meta( $links, $file ) {
 	if ( strpos( $file, 'pmpro-network-subsite.php' ) !== false ) {
 		$new_links = array(
-			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-network-membership/' ) . '" title="' . esc_attr( __( 'View Documentation', 'pmpro-multisite-membership' ) ) . '">' . __( 'Docs', 'pmpro-multisite-membership' ) . '</a>',
-			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr( __( 'Visit Customer Support Forum', 'pmpro-multisite-membership' ) ) . '">' . __( 'Support', 'pmpro-multisite-membership' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/add-ons/pmpro-network-membership/' ) . '" title="' . esc_attr__( 'View Documentation', 'pmpro-multisite-membership' ) . '">' . esc_html__( 'Docs', 'pmpro-multisite-membership' ) . '</a>',
+			'<a href="' . esc_url( 'https://www.paidmembershipspro.com/support/' ) . '" title="' . esc_attr__( 'Visit Customer Support Forum', 'pmpro-multisite-membership' ) . '">' . esc_html__( 'Support', 'pmpro-multisite-membership' ) . '</a>',
 		);
 		$links = array_merge( $links, $new_links );
 	}


### PR DESCRIPTION
* Corrected the text domain slug and loaded it on `init`
* Escaped output where possible.

Resolves: #21 

Todo: Run action to generate translation files and folder.