### PR TITLE
Deactivate non multisite

### DIFF
--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -11,6 +11,20 @@
  */
 
 /**
+ * Deactivate this plugin automatically if we're not on a multisite installation.
+ */
+function pmpro_multisite_deactivate_self() {
+	if ( is_multisite() ) {
+		return;
+	}
+
+	add_action( 'admin_notices', 'pmpro_multisite_show_admin_warning' );
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+}
+add_action( 'admin_init', 'pmpro_multisite_deactivate_self' );
+
+
+/**
  * Show an admin notice that the plugin has been deactivated.
  */
 function pmpro_multisite_show_admin_warning() {
@@ -22,19 +36,6 @@ function pmpro_multisite_show_admin_warning() {
 		<?php
 	}
 }
-add_action( 'admin_notices', 'pmpro_multisite_show_admin_warning' );
-
-/**
- * Deactivate this plugin automatically if we're not on a multisite installation.
- */
-function pmpro_multisite_deactivate_self() {
-	if ( is_multisite() ) {
-		return;
-	}
-
-	deactivate_plugins( plugin_basename( __FILE__ ) );
-}
-add_action( 'admin_init', 'pmpro_multisite_deactivate_self' );
 
 // Don't run this plugin if it's not a multisite.
 if ( ! is_multisite() ) {

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -10,6 +10,28 @@
  * Domain Path: /languages
  */
 
+function pmpro_multisite_show_admin_warning() {
+	if ( ! is_multisite() ) {
+		?>
+		<div class="error">
+			<p><?php esc_html_e( 'The Paid Memberships Pro - Multisite Membership Add-On is compatible only with multisite installations. We have automatically deactivated this plugin.', 'pmpro-network-subsite' ); ?></p>
+		</div>
+		<?php
+	}
+}
+add_action( 'admin_notices', 'pmpro_multisite_show_admin_warning' );
+
+
+// Deactivate this plugin if it's not a multisite automatically.
+function pmpro_multisite_deactivate_self() {
+	deactivate_plugins( plugin_basename( __FILE__ ) );
+}
+add_action( 'admin_init', 'pmpro_multisite_deactivate_self' );
+
+// Don't run this plugin if it's not a multisite.
+if ( ! is_multisite() ) {
+	return;
+}
 /** 
  * Get the Main DB Prefix
  *

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -24,6 +24,10 @@ add_action( 'admin_notices', 'pmpro_multisite_show_admin_warning' );
 
 // Deactivate this plugin if it's not a multisite automatically.
 function pmpro_multisite_deactivate_self() {
+	if ( is_multisite() ) {
+		return;
+	}
+
 	deactivate_plugins( plugin_basename( __FILE__ ) );
 }
 add_action( 'admin_init', 'pmpro_multisite_deactivate_self' );


### PR DESCRIPTION
* Deactivate this plugin automatically and show a warning on non-multisite installations.

Resolves: https://github.com/strangerstudios/pmpro-network-subsite/issues/19