### PR TITLE
New option to inherit all settings from the main network site or customize per site; now using upcoming core PMPro avatar filters to support avatars loaded from main site

### DIFF
--- a/inc/class-pmpro-manage-multisite.php
+++ b/inc/class-pmpro-manage-multisite.php
@@ -24,7 +24,9 @@ class PMPro_Manage_Multisite {
 
 		// Add submenu advanced settings page.
 		add_submenu_page( 'pmpro-network-subsite', 'Settings', 'Settings', 'read', 'pmpro-network-subsite',  array( __CLASS__, 'settings_page' ) ); //Add this so we can have a menu slug for the main menu link
-		add_submenu_page( 'pmpro-network-subsite', esc_html__( 'Advanced Settings', 'pmpro-multisite-membership' ), esc_html__( 'Advanced Settings', 'pmpro-multisite-membership' ), 'manage_options', 'pmpro-advancedsettings', 'pmpro_advancedsettings' );
+		if ( get_option( 'pmpro_multisite_advanced_settings_source', 'inherit' ) === 'custom' ) {
+			add_submenu_page( 'pmpro-network-subsite', esc_html__( 'Advanced Settings', 'pmpro-multisite-membership' ), esc_html__( 'Advanced Settings', 'pmpro-multisite-membership' ), 'manage_options', 'pmpro-advancedsettings', 'pmpro_advancedsettings' );
+		}
 
 		// Only load the styling when we're on one of our admin pages.
 		if ( ! empty( $_REQUEST['page'] ) && ( $_REQUEST['page'] == 'pmpro-network-subsite'
@@ -62,9 +64,12 @@ class PMPro_Manage_Multisite {
 			$main_db_prefix = sanitize_text_field( $_POST['main_db_prefix'] );
 			update_site_option( 'pmpro_multisite_membership_main_db_prefix', $main_db_prefix );
 			delete_site_transient( 'pmpro_multisite_membership_main_site_id' ); // Clear the transient on save.
+
+			$advanced_settings_source = ( ! empty( $_POST['advanced_settings_source'] ) && 'custom' === $_POST['advanced_settings_source'] ) ? 'custom' : 'inherit';
+			update_option( 'pmpro_multisite_advanced_settings_source', $advanced_settings_source );
 			?>
-			<div id=="message" class="updated fade">
-				<p><?php esc_html_e( 'The source site has been updated. Make sure that PMPro IS active on that site and the Multisite Membership Add On IS NOT active there.', 'pmpro-network-subsite' ); ?></p>
+			<div id="message" class="updated fade">
+				<p><?php esc_html_e( 'Settings saved.', 'pmpro-network-subsite' ); ?></p>
 			</div>
 			<?php
 		}
@@ -75,6 +80,13 @@ class PMPro_Manage_Multisite {
 
 ?>
 <h1><?php esc_html_e( 'Multisite Membership', 'pmpro-network-subsite' ); ?></h1>
+<p>
+	<?php esc_html_e( 'For sites using WordPress multisite network, use this Add On for centralized membership checkout, login, and admin on the main network site and restrict access to content across all of your subsites.', 'pmpro-network-subsite' ); ?>
+	<?php
+	$nav_menus_link = '<a title="' . esc_attr__( 'Multisite Membership Add On Documentation', 'pmpro-network-subsite' ) . '" target="_blank" rel="nofollow noopener" href="https://www.paidmembershipspro.com/add-ons/pmpro-network-membership/?utm_source=plugin&utm_medium=pmpro-network-subsite&utm_campaign=add-ons">' . esc_html__( 'Multisite Membership', 'pmpro-network-subsite' ) . '</a>';
+	printf( esc_html__( 'Learn more about %s.', 'pmpro-network-subsite' ), $nav_menus_link ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	?>
+</p>
 <form id="select-site-form" action="" method="POST">
 	<?php wp_nonce_field( 'pmpro_multisite_membership_settings', 'pmpro_multisite_membership_settings_nonce' ); ?>
 	<div id="pmpro-network-subsite-level-settings" class="pmpro_section" data-visibility="show" data-activated="true">
@@ -86,7 +98,6 @@ class PMPro_Manage_Multisite {
 		</div> <!-- end pmpro_section_toggle -->
 		<div class="pmpro_section_inside">
 			<p><?php printf( esc_html__( 'You have activated the %s on this site, which means that you will be using PMPro settings from another site in your Network to control site access.', 'pmpro-network-subsite' ), '<strong>' . __( 'Multisite Membership Add On', 'pmpro-network-subsite' ) . '</strong>' );?></p>
-			<p><?php esc_html_e( 'Select the site you would like to get PMPro level data from and click Update.', 'pmpro-network-subsite' );?></p>
 			<table class="form-table">
 				<tbody>
 					<tr>
@@ -97,8 +108,6 @@ class PMPro_Manage_Multisite {
 								$sites = get_sites( array( 'public' => 1 ) );
 								$bool_val = SUBDOMAIN_INSTALL;
 								foreach ( $sites as $site ) {
-									var_dump( $site );
-
 									// Exclude the current site.
 									if ( $site->blog_id == get_current_blog_id() ) {
 										continue;
@@ -115,6 +124,20 @@ class PMPro_Manage_Multisite {
 								}
 							?>
 							</select>
+							<p class="description"><?php esc_html_e( 'Select the site you would like to get PMPro level data from and click Update.', 'pmpro-network-subsite' );?></p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row" valign="top">
+							<label for="advanced_settings_source"><?php esc_html_e( 'Advanced Settings', 'pmpro-network-subsite' ); ?></label>
+						</th>
+						<td>
+							<?php $source = get_option( 'pmpro_multisite_advanced_settings_source', 'inherit' ); ?>
+							<select id="advanced_settings_source" name="advanced_settings_source">
+								<option value="inherit" <?php selected( $source, 'inherit' ); ?>><?php esc_html_e( 'Use main site settings', 'pmpro-network-subsite' ); ?></option>
+								<option value="custom" <?php selected( $source, 'custom' ); ?>><?php esc_html_e( 'Use custom settings for this subsite', 'pmpro-network-subsite' ); ?></option>
+							</select>
+							<p class="description"><?php esc_html_e( 'By default, subsites use the PMPro settings from the main site. To use custom settings for this subsite, change this option. A new Advanced Settings screen will appear under the Memberships menu.', 'pmpro-network-subsite' ); ?></p>
 						</td>
 					</tr>
 				</tbody>

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -66,6 +66,10 @@ function pmpro_multisite_membership_get_main_db_prefix() {
 		update_site_option( 'pmpro_multisite_membership_main_db_prefix', $main_db_prefix );
 	}
 
+	// Strip any characters that are not valid in a MySQL identifier to prevent
+	// SQL injection via a crafted prefix stored by a superadmin.
+	$main_db_prefix = preg_replace( '/[^a-zA-Z0-9_]/', '', $main_db_prefix );
+
 	return $main_db_prefix;
 }
 
@@ -101,10 +105,11 @@ function pmpro_multisite_get_advanced_settings_option_names() {
 		'pmpro_wisdom_opt_out',
 		'pmpro_hideadslevels',
 		'pmpro_redirecttosubscription',
-		'pmpro_uninstall',
 		'pmpro_avatar_enabled_sitewide',
 		'pmpro_site_type',
-		'show_avatars', // WP Discussion setting; required for any PMPro avatar display.
+		// show_avatars is a WP core Discussion setting. While in inherit mode, subsite admin
+		// changes to Settings → Discussion → Show Avatars will have no visible effect.
+		'show_avatars',
 	) );
 }
 

--- a/pmpro-network-subsite.php
+++ b/pmpro-network-subsite.php
@@ -72,6 +72,137 @@ function pmpro_multisite_membership_get_main_db_prefix() {
 include( 'inc/class-pmpro-manage-multisite.php' );
 PMPro_Manage_Multisite::init();
 
+/**
+ * Get the advanced settings source for the current subsite.
+ *
+ * @return string 'inherit' to pull from the main site, 'custom' to use per-subsite settings.
+ */
+function pmpro_multisite_get_advanced_settings_source() {
+	return get_option( 'pmpro_multisite_advanced_settings_source', 'inherit' );
+}
+
+/**
+ * The PMPro option names managed on the Advanced Settings screen.
+ * Filterable so add-ons can append their own options.
+ *
+ * @return string[]
+ */
+function pmpro_multisite_get_advanced_settings_option_names() {
+	return apply_filters( 'pmpro_multisite_advanced_settings_options', array(
+		'pmpro_hide_toolbar',
+		'pmpro_block_dashboard',
+		'pmpro_filterqueries',
+		'pmpro_showexcerpts',
+		'pmpro_nonmembertext',
+		'pmpro_maxnotificationpriority',
+		'pmpro_activity_email_frequency',
+		'pmpro_business_address',
+		'pmpro_hideads',
+		'pmpro_wisdom_opt_out',
+		'pmpro_hideadslevels',
+		'pmpro_redirecttosubscription',
+		'pmpro_uninstall',
+		'pmpro_avatar_enabled_sitewide',
+		'pmpro_site_type',
+		'show_avatars', // WP Discussion setting; required for any PMPro avatar display.
+	) );
+}
+
+/**
+ * When "inherit" mode is active, register pre_option_* filters that read each
+ * Advanced Settings option directly from the main site's options table.
+ * Using pre_option_* + a direct DB read avoids any get_blog_option() recursion.
+ */
+function pmpro_multisite_register_advanced_settings_inheritance() {
+	if ( pmpro_multisite_get_advanced_settings_source() !== 'inherit' ) {
+		return;
+	}
+
+	$main_db_prefix = pmpro_multisite_membership_get_main_db_prefix();
+	if ( empty( $main_db_prefix ) ) {
+		return;
+	}
+
+	foreach ( pmpro_multisite_get_advanced_settings_option_names() as $option_name ) {
+		add_filter(
+			'pre_option_' . $option_name,
+			static function() use ( $main_db_prefix, $option_name ) {
+				global $wpdb;
+				$row = $wpdb->get_row(
+					$wpdb->prepare(
+						"SELECT option_value FROM `{$main_db_prefix}options` WHERE option_name = %s LIMIT 1",
+						$option_name
+					)
+				);
+				if ( is_object( $row ) ) {
+					return maybe_unserialize( $row->option_value );
+				}
+				return false;
+			}
+		);
+	}
+
+	// pmpro_filterqueries is read at plugin-load time in content.php (global scope, before
+	// pre_option_* filters can intercept it). Correct the resulting pre_get_posts hook on
+	// init priority 1, before any queries run.
+	add_action( 'init', static function() use ( $main_db_prefix ) {
+		global $wpdb;
+		remove_filter( 'pre_get_posts', 'pmpro_search_filter' );
+		$row = $wpdb->get_row( $wpdb->prepare(
+			"SELECT option_value FROM `{$main_db_prefix}options` WHERE option_name = %s LIMIT 1",
+			'pmpro_filterqueries'
+		) );
+		if ( is_object( $row ) && ! empty( $row->option_value ) ) {
+			add_filter( 'pre_get_posts', 'pmpro_search_filter' );
+		}
+	}, 1 );
+
+	// Avatars are uploaded to the main site. Point PMPro's avatar path helpers at the
+	// main site's upload directory via dedicated filters added to PMPro core.
+	add_filter( 'pmpro_avatar_basedir', 'pmpro_multisite_avatar_basedir' );
+	add_filter( 'pmpro_avatar_baseurl', 'pmpro_multisite_avatar_baseurl' );
+}
+add_action( 'plugins_loaded', 'pmpro_multisite_register_advanced_settings_inheritance', 20 );
+
+/**
+ * Get the main site's upload directory info, cached for the request.
+ *
+ * @return array wp_upload_dir() result for the main site.
+ */
+function pmpro_multisite_get_main_upload_dir() {
+	static $main_upload = null;
+
+	if ( null === $main_upload ) {
+		switch_to_blog( pmpro_multisite_get_main_site_ID() );
+		$main_upload = wp_upload_dir();
+		restore_current_blog();
+	}
+
+	return $main_upload;
+}
+
+/**
+ * Redirect PMPro avatar basedir to the main site's uploads directory.
+ *
+ * @param string $basedir The current basedir.
+ * @return string The main site's basedir.
+ */
+function pmpro_multisite_avatar_basedir( $basedir ) {
+	$main_upload = pmpro_multisite_get_main_upload_dir();
+	return $main_upload['basedir'];
+}
+
+/**
+ * Redirect PMPro avatar baseurl to the main site's uploads URL.
+ *
+ * @param string $baseurl The current baseurl.
+ * @return string The main site's baseurl.
+ */
+function pmpro_multisite_avatar_baseurl( $baseurl ) {
+	$main_upload = pmpro_multisite_get_main_upload_dir();
+	return $main_upload['baseurl'];
+}
+
 // Load text domain
 function pmpro_multisite_membership_load_textdomain() {
 	load_plugin_textdomain( 'pmpro-network-subsite', false, basename( dirname( __FILE__ ) ) . '/languages' ); 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-network-subsite/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-network-subsite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added new setting to allow the subsite to inherit advanced settings from the main site.

Added filters upcoming in PMPro (requires PR https://github.com/strangerstudios/paid-memberships-pro/pull/3648) to support avatars across the network as managed at the main network site.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* FEATURE: Added option to inherit advanced settings from the main network site.
* BUG FIX/ENHANCEMENT: Now using the member avatars as created in the main network site.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
