### PR TITLE
close form tag before footer

### DIFF
--- a/inc/class-pmpro-manage-multisite.php
+++ b/inc/class-pmpro-manage-multisite.php
@@ -147,7 +147,7 @@ class PMPro_Manage_Multisite {
 			</p>
 		</div> <!-- end pmpro_section_inside -->
 	</div> <!-- end pmpro_section -->
-</div> <!-- end pmpro_admin wrap -->
+</form> <!-- end form -->
 
 <?php
 		if( defined( 'PMPRO_DIR' ) ) {


### PR DESCRIPTION
closed div tag instead of closed form tag  is making footer message appear in the content area of the admin page.

### All Submissions:

* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-network-subsite/blob/dev/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-network-subsite/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
